### PR TITLE
Acts as favoritor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'redis', '~> 4.0'
 # Custom-added gems
 gem 'cloudinary', '~> 1.16.0'
 gem 'acts-as-taggable-on'
+gem 'acts_as_favoritor'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.4', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,8 @@ GEM
       zeitwerk (~> 2.3)
     acts-as-taggable-on (8.1.0)
       activerecord (>= 5.0, < 6.2)
+    acts_as_favoritor (5.0.1)
+      activerecord (>= 5.0)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     autoprefixer-rails (10.2.5.0)
@@ -133,8 +135,6 @@ GEM
     netrc (0.11.0)
     nio4r (2.5.8)
     nokogiri (1.12.3-x86_64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.12.3-x86_64-linux)
       racc (~> 1.4)
     orm_adapter (0.5.0)
     pg (1.2.3)
@@ -262,6 +262,7 @@ PLATFORMS
 
 DEPENDENCIES
   acts-as-taggable-on
+  acts_as_favoritor
   autoprefixer-rails (= 10.2.5)
   bootsnap (>= 1.4.4)
   byebug
@@ -293,4 +294,4 @@ RUBY VERSION
    ruby 2.7.3p183
 
 BUNDLED WITH
-   2.2.25
+   2.2.26

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,6 +136,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.12.3-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.12.3-x86_64-linux)
+      racc (~> 1.4)
     orm_adapter (0.5.0)
     pg (1.2.3)
     pry (0.13.1)

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class Favorite < ApplicationRecord
+  extend ActsAsFavoritor::FavoriteScopes
+
+  belongs_to :favoritable, polymorphic: true
+  belongs_to :favoritor, polymorphic: true
+
+  def block!
+    update!(blocked: true)
+  end
+end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,4 +1,5 @@
 class Product < ApplicationRecord
   has_one_attached :photo
   has_many :reviews
+  acts_as_favoritable
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
   has_many :reviews
   has_one_attached :photo
+  acts_as_favoritor
 
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable

--- a/config/initializers/acts_as_favoritor.rb
+++ b/config/initializers/acts_as_favoritor.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+ActsAsFavoritor.configure do |config|
+  # Specify your default scope. Learn more about scopes here: https://github.com/jonhue/acts_as_favoritor#scopes
+  # config.default_scope = :favorite
+
+  # Enable caching. Learn more about caching here: https://github.com/jonhue/acts_as_favoritor#caching
+  # config.cache = false
+end

--- a/db/migrate/20210824031312_acts_as_favoritor_migration.rb
+++ b/db/migrate/20210824031312_acts_as_favoritor_migration.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class ActsAsFavoritorMigration < ActiveRecord::Migration[6.1]
+  def self.up
+    create_table :favorites, force: true do |t|
+      t.references :favoritable, polymorphic: true, null: false
+      t.references :favoritor, polymorphic: true, null: false
+      t.string :scope, default: ActsAsFavoritor.configuration.default_scope,
+                       null: false,
+                       index: true
+      t.boolean :blocked, default: false, null: false, index: true
+      t.timestamps
+    end
+
+    add_index :favorites,
+              ['favoritor_id', 'favoritor_type'],
+              name: 'fk_favorites'
+    add_index :favorites,
+              ['favoritable_id', 'favoritable_type'],
+              name: 'fk_favoritables'
+  end
+
+  def self.down
+    drop_table :favorites
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_23_115133) do
+ActiveRecord::Schema.define(version: 2021_08_24_031312) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,6 +41,23 @@ ActiveRecord::Schema.define(version: 2021_08_23_115133) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "favorites", force: :cascade do |t|
+    t.string "favoritable_type", null: false
+    t.bigint "favoritable_id", null: false
+    t.string "favoritor_type", null: false
+    t.bigint "favoritor_id", null: false
+    t.string "scope", default: "favorite", null: false
+    t.boolean "blocked", default: false, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["blocked"], name: "index_favorites_on_blocked"
+    t.index ["favoritable_id", "favoritable_type"], name: "fk_favoritables"
+    t.index ["favoritable_type", "favoritable_id"], name: "index_favorites_on_favoritable"
+    t.index ["favoritor_id", "favoritor_type"], name: "fk_favorites"
+    t.index ["favoritor_type", "favoritor_id"], name: "index_favorites_on_favoritor"
+    t.index ["scope"], name: "index_favorites_on_scope"
   end
 
   create_table "products", force: :cascade do |t|


### PR DESCRIPTION
This implements the basic configuration for the `acts_as_favoritor` gem. The Product model now has the `acts_as_favoritable` attribute and the User model now has the `acts_as_favoritor` attribute.