### PR TITLE
add acts_as_taggable_on :tags to Product model

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,4 +1,5 @@
 class Product < ApplicationRecord
   has_one_attached :photo
   has_many :reviews
+  acts_as_taggable_on :tags
 end


### PR DESCRIPTION
Product model can now have :tags.

Refer to the kitt documentation ([https://kitt.lewagon.com/knowledge/tutorials/acts_as_taggable](url)) and the full documentation ([https://github.com/mbleigh/acts-as-taggable-on/](url)) for usage instructions.