### PR TITLE
Fix display_name validation

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,5 @@ class User < ApplicationRecord
 
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
-
-  validates :display_name, length: { within: 5..12 }
+  validates :display_name, length: { within: 5..12 }, allow_blank: true
 end

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -6,13 +6,13 @@
     <!-- <p class="my-auto">Navbar punchline</p> -->
     <% cl_image = cl_image_tag("https://dummyimage.com/25x25/fff/000&text=%3F", type: "fetch", class: "rounded-circle my-auto") %>
   <% else %>
-    <% username = current_user.display_name || current_user.email.split('@')[0] %>
+    <% username = current_user.display_name.blank? ? current_user.email.split('@')[0] : current_user.display_name  %>
     <!-- <p class="my-auto">Navbar punchline <%= username %></p> -->
     <p class="my-auto"><%= username %></p>
     <% if current_user.photo.attached? %>
       <% cl_image = cl_image_tag(current_user.photo.key, class: "rounded-circle my-auto", width: 24, height: 24) %>
     <% else %>
-      <% initial = current_user.display_name.nil? ? current_user.email[0].upcase : current_user.display_name[0].upcase; %>
+      <% initial = current_user.display_name.blank? ? current_user.email[0].upcase : current_user.display_name[0].upcase; %>
       <% cl_image = cl_image_tag("https://dummyimage.com/25x25/fff/000&text=#{initial}", type: "fetch", class: "rounded-circle my-auto") %>
     <% end %>
   <% end %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -6,13 +6,13 @@
     <!-- <p class="my-auto">Navbar punchline</p> -->
     <% cl_image = cl_image_tag("https://dummyimage.com/25x25/fff/000&text=%3F", type: "fetch", class: "rounded-circle my-auto") %>
   <% else %>
-    <% username = current_user.display_name.blank? ? current_user.email.split('@')[0] : current_user.display_name  %>
+    <% username = (current_user.display_name.blank? || current_user.display_name.nil?) ? current_user.email.split('@')[0] : current_user.display_name  %>
     <!-- <p class="my-auto">Navbar punchline <%= username %></p> -->
     <p class="my-auto"><%= username %></p>
     <% if current_user.photo.attached? %>
       <% cl_image = cl_image_tag(current_user.photo.key, class: "rounded-circle my-auto", width: 24, height: 24) %>
     <% else %>
-      <% initial = current_user.display_name.blank? ? current_user.email[0].upcase : current_user.display_name[0].upcase; %>
+      <% initial = (current_user.display_name.blank? || current_user.display_name.nil?) ? current_user.email[0].upcase : current_user.display_name[0].upcase; %>
       <% cl_image = cl_image_tag("https://dummyimage.com/25x25/fff/000&text=#{initial}", type: "fetch", class: "rounded-circle my-auto") %>
     <% end %>
   <% end %>


### PR DESCRIPTION
Corrected signup behavior such that new users can register without a `display_name`. 

If a user wants to add a `display_name` at signup (or later on their edit account page), the length of `display_name` will be validated (between 5 and 12 characters).

The header HTML has been updated to account for the fact that `display_name` can be either nil (through our seeds) or a blank string `""` if the user does not set a display_name at signup.

Error encountered when `display_name` is a blank string (from user not setting one at signup).
![Screen Shot 2021-08-25 at 14 41 15](https://user-images.githubusercontent.com/31387233/130735360-fd23a050-0403-4756-bf99-9b6456db1a9c.png)

Calling `current_user.display_name.blank?` will return `true` when `current_user.display_name.nil?` does not.
![Screen Shot 2021-08-25 at 14 41 33](https://user-images.githubusercontent.com/31387233/130735423-0b26fa54-0307-4268-a879-14b15dfd6ab0.png)

Our code will now check whether either `current_user.display_name.blank?` or `current_user.display_name.nil?` return `true`.


