### PR TITLE
Link scanner to modal

### DIFF
--- a/app/views/shared/_home_banner.html.erb
+++ b/app/views/shared/_home_banner.html.erb
@@ -10,9 +10,11 @@
           </button>
         </div>
         <% body_content = render 'shared/barcode_scanner' %>
-        <%= body_content %>
+        <%= render 'shared/modal', modal_id: 'camera', modal_title: 'Camera', 
+        text_header: "It's time to snap!", text_body: 'Show me your barcode!', body_content: body_content,
+        redirect_path: root_path, btn_modal_confirm: 'Home'  %>
         <div class="d-flex bd-highlight m-3">
-          <a class="btn btn btn-dark flex-grow-1 justify-content-between" data-toggle="modal" data-target="#takePhoto">
+          <a class="btn btn btn-dark flex-grow-1 justify-content-between" data-toggle="modal" data-target="#camera">
             <i class="fas fa-camera"></i> Scan a barcode!
           </a>
           <a href="" class="btn btn-dark ml-3" data-toggle="modal" data-target="#takePhoto">

--- a/app/views/shared/_home_banner.html.erb
+++ b/app/views/shared/_home_banner.html.erb
@@ -9,6 +9,8 @@
             <span aria-hidden="true">&times;</span>
           </button>
         </div>
+        <% body_content = render 'shared/barcode_scanner' %>
+        <%= body_content %>
         <div class="d-flex bd-highlight m-3">
           <a class="btn btn btn-dark flex-grow-1 justify-content-between" data-toggle="modal" data-target="#takePhoto">
             <i class="fas fa-camera"></i> Scan a barcode!

--- a/app/views/shared/_modal.html.erb
+++ b/app/views/shared/_modal.html.erb
@@ -13,6 +13,7 @@
           <h5><%= text_header %></h5>
         <% end %>
         <p><%= text_body %></p>
+        <%= body_content if body_content %>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>


### PR DESCRIPTION
This will be as far as I go with linking access to the camera. After this @2tonepantone will take over and optimize it.

![image](https://user-images.githubusercontent.com/78134040/130775115-8666c148-40e5-4e12-bf95-86f0e907bf0a.png)

1) Click on 'Barcode Snap!' button to open the first modal.
![image](https://user-images.githubusercontent.com/78134040/130775140-e1daff68-9a0a-4afa-9510-a5593084d1f5.png)

2) Click on 'Scan a barcode!' to show the camera modal, and then show the barcode to the camera.
![image](https://user-images.githubusercontent.com/78134040/130775394-862cf39e-6adf-4bb7-aaa2-85dde5bdea71.png)

3) Once the barcode is scanned. It will redirect to the product page automatically.
![image](https://user-images.githubusercontent.com/78134040/130775506-22345d06-f9dc-45b9-a82e-0bc09be733e8.png)

3.5) If the web can't scrape the data from the website with a given barcode number, it will redirect to the root (with an error message).
![image](https://user-images.githubusercontent.com/78134040/130775673-47b06bce-1409-4e08-b12b-37f7d80d7e3c.png)
