### PR TITLE
add barcode format check and fixer

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -8,7 +8,6 @@ class ProductsController < ApplicationController
   def create
     @barcode = params[:barcode]
 
-    # check barcode length/format, change it if not 13
     @barcode = convert_to_jancode unless jancode_format?
 
     if in_database?
@@ -36,10 +35,6 @@ class ProductsController < ApplicationController
 
   def convert_to_jancode
     "0" * (13 - @barcode.length) + @barcode
-  end
-
-  def scrape_jancode
-    # put scrape method here
   end
 
   def in_database?


### PR DESCRIPTION
This should fix the scanner making duplicate products when the the barcode is not 13 characters (i.e. the EAN-13/JAN code standard).