### PR TITLE
Add 'fake' index page for products.

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -2,32 +2,20 @@ class ProductsController < ApplicationController
   skip_before_action :authenticate_user!, only: %i[show create]
 
   def show
-    @product = Product.find(params[:id])
-    
+    @product = Product.find(params[:id]) if params[:id].to_i.positive?
+
     # If product_id exists, generate @product_compare
     if !params[:product_id].nil?
       @product_compare = Product.find(params[:product_id])
     end
-    
+
     # If sort_by key exists, generate @products
     return unless params.key? :sort_by
 
-    case params[:sort_by]
-    when "most_related"
-      @products = @product.find_related_on_tags
-    when "most_favorited"
-      @products = @product.find_related_on_tags.sort_by { |p| p.favoritors.count }.reverse
-    when "high_rating"
-      @products = @product.find_related_on_tags.sort_by do |p|
-        reviews = p.reviews
-        rating = reviews.count.positive? ? (reviews.map(&:rating).sum / reviews.count).round(2) : 0
-        rating
-      end.reverse
-    when "newest"
-      @products = @product.find_related_on_tags.sort_by(&:created_at).reverse
+    if @product.nil? && params[:id] == '0'
+      @products = get_all_product_sorted
     else
-      params[:sort_by] = "oldest"
-      @products = @product.find_related_on_tags.sort_by(&:created_at)
+      @products = get_related_product_sorted(@product)
     end
   end
 
@@ -67,6 +55,45 @@ class ProductsController < ApplicationController
     Product.exists?(barcode: @barcode)
   end
 
+  def get_all_product_sorted
+    case params[:sort_by]
+    when "most_related"
+      @products = Product.all
+    when "most_favorited"
+      @products = Product.all.sort_by { |p| p.favoritors.count }.reverse
+    when "top_rating"
+      @products = Product.all.sort_by do |p|
+        reviews = p.reviews
+        rating = reviews.count.positive? ? (reviews.map(&:rating).sum / reviews.count).round(2) : 0
+        rating
+      end.reverse
+    when "newest"
+      @products = Product.order(created_at: :desc)
+    else
+      params[:sort_by] = "oldest"
+      @products = Product.order(:created_at)
+    end
+  end
+
+  def get_related_product_sorted(product)
+    case params[:sort_by]
+    when "most_related"
+      @products = product.find_related_on_tags
+    when "most_favorited"
+      @products = product.find_related_on_tags.sort_by { |p| p.favoritors.count }.reverse
+    when "top_rating"
+      @products = product.find_related_on_tags.sort_by do |p|
+        reviews = p.reviews
+        rating = reviews.count.positive? ? (reviews.map(&:rating).sum / reviews.count).round(2) : 0
+        rating
+      end.reverse
+    when "newest"
+      @products = product.find_related_on_tags.sort_by(&:created_at).reverse
+    else
+      params[:sort_by] = "oldest"
+      @products = product.find_related_on_tags.sort_by(&:created_at)
+    end
+  end
   # def product_params
   #   params.require(:product).permit(:name, :barcode, :company_name,
   #                                   :ingredients, :size, :photo, :reviews, :tags)

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -8,7 +8,9 @@
         <h4 class="mb-1">Top rating</h4>
       </div>
       <div class="col">
-        <a href="" class="mb-1 text-right mr-3" style="position: absolute; bottom:0; right:0;">More<i class="fas fa-chevron-right"></i></a>
+        <%=  link_to (product_path(0) + '?sort_by=top_rating') do %>
+          <span class="mb-1 text-right mr-3" style="position: absolute; bottom:0; right:0;">More<i class="fas fa-chevron-right"></i></span>
+        <% end %>
       </div>
     </div>
     <div class="cards-product">
@@ -39,7 +41,9 @@
         <h4 class="mt-3 mb-1">Loved by the people</i></h4>
     </div>
     <div class="col">
-      <a href="" class="mb-1 text-right mr-3" style="position: absolute; bottom:0; right:0;">More<i class="fas fa-chevron-right"></i></a>
+      <%=  link_to (product_path(0) + '?sort_by=most_favorited') do %>
+        <span class="mb-1 text-right mr-3" style="position: absolute; bottom:0; right:0;">More<i class="fas fa-chevron-right"></i></span>
+      <% end %>
     </div>
   </div>
   <div class="cards-product">

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -16,8 +16,8 @@
             <%=  link_to (product_path + '?sort_by=most_favorited') do %>
               <span class="dropdown-item">Most favorited</span>
             <% end %>
-            <%=  link_to (product_path + '?sort_by=high_rating') do %>
-              <span class="dropdown-item">High rating</span>
+            <%=  link_to (product_path + '?sort_by=top_rating') do %>
+              <span class="dropdown-item">Top rating</span>
             <% end %>
             <%=  link_to (product_path + '?sort_by=oldest') do %>
               <span class="dropdown-item">Oldest</span>
@@ -100,7 +100,7 @@
   <% else %>
     <!-- Product info compare -->
     <div style ="margin-right:-15px">
-      <%= render 'shared/product_info_comparison', product_name: @product.name, product_name_compare: @product_compare.name, bg_img_url:@product.photo.attached? ? cl_image_path(@product.photo.key , height: 300, width: 400, crop: :fill) : image_path("https://i.ytimg.com/vi/I4rS15xBL1Y/maxresdefault.jpg"), bg_img_url_compare: @product_compare.photo.attached? ? cl_image_path(@product_compare.photo.key , height: 300, width: 400, crop: :fill) : image_path("https://i.ytimg.com/vi/I4rS15xBL1Y/maxresdefault.jpg"), rating:"4.7", rating_compare:"4.2", company_name: @product.company_name, company_name_compare: @product_compare.company_name, price: "¥100", price_compare:"¥50", ingredients: @product.ingredients, ingredients_compare: @product_compare.ingredients, size: @product.size, size_compare: @product_compare.size%>
+      <%= render 'shared/product_info_comparison', product_name: @product.name, product_name_compare: @product_compare.name, bg_img_url:@product.photo.attached? ? cl_image_path(@product.photo.key , height: 300, width: 400, crop: :fill) : image_path("https://dummyimage.com/300x300/fff/000&text=X"), bg_img_url_compare: @product_compare.photo.attached? ? cl_image_path(@product_compare.photo.key , height: 300, width: 400, crop: :fill) : image_path("https://dummyimage.com/300x300/fff/000&text=X"), rating:"4.7", rating_compare:"4.2", company_name: @product.company_name, company_name_compare: @product_compare.company_name, price: "¥100", price_compare:"¥50", ingredients: @product.ingredients, ingredients_compare: @product_compare.ingredients, size: @product.size, size_compare: @product_compare.size%>
     </div>
     <!-- product_card -->
     <div class="row" style="position: relative;">


### PR DESCRIPTION
 This fake index page behaving like a related product page but it will show every product instead of products that are related to the target product.

![image](https://user-images.githubusercontent.com/78134040/130930892-195c4e8e-4d29-4a81-af83-4a4255b578d0.png)
![image](https://user-images.githubusercontent.com/78134040/130930914-09668547-1a52-4fd1-b14c-c221c8fbaf80.png)

![image](https://user-images.githubusercontent.com/78134040/130930978-16cc5ed3-6e30-4a23-b88a-2172f3d79ad1.png)
![image](https://user-images.githubusercontent.com/78134040/130931021-cf7e6a86-eb35-423e-9ae4-2bc4f1928409.png)
