### PR TITLE
Implement google translate

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -34,9 +34,9 @@ body a {
   background-color: #6c757d;
 }
 
-// .goog-te-banner-frame.skiptranslate {
-//         display: none !important;
-//     }
-// body {
-//     top: 0px !important;
-// }
+.goog-te-banner-frame.skiptranslate {
+        display: none !important;
+    }
+body {
+    top: 0px !important;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -34,9 +34,6 @@ body a {
   background-color: #6c757d;
 }
 
-.goog-te-banner-frame.skiptranslate {
-        display: none !important;
-    }
 body {
     top: 0px !important;
 }

--- a/app/assets/stylesheets/components/_google_translate.scss
+++ b/app/assets/stylesheets/components/_google_translate.scss
@@ -2,6 +2,10 @@
   position: static;
 }
 
+#google-translate-container {
+  width: 35px;
+}
+
 .goog-te-banner-frame.skiptranslate {
   display: none !important;
 }
@@ -11,13 +15,18 @@
 } 
 
 .goog-te-combo {
-  width: 16px;
+  width: 35px;
+  opacity: 0;
   border: none;
   background: none;
 }
 
 #fa-translate-icon {
-  font-size: 24px;
+  font-size: 28px;
+}
+
+#fa-translate-chevron {
+  font-size: 12px;
 }
 
 .skiptranslate.goog-te-gadget{

--- a/app/assets/stylesheets/components/_google_translate.scss
+++ b/app/assets/stylesheets/components/_google_translate.scss
@@ -1,0 +1,25 @@
+#google_translate_element {
+  position: static;
+}
+
+.goog-te-banner-frame.skiptranslate {
+  display: none !important;
+}
+
+.goog-logo-link {
+  display:none !important;
+} 
+
+.goog-te-combo {
+  width: 16px;
+  border: none;
+  background: none;
+}
+
+#fa-translate-icon {
+  font-size: 24px;
+}
+
+.skiptranslate.goog-te-gadget{
+  font-size: 0px;
+}

--- a/app/assets/stylesheets/components/_google_translate.scss
+++ b/app/assets/stylesheets/components/_google_translate.scss
@@ -14,6 +14,21 @@
   display:none !important;
 } 
 
+#goog-gt-tt {
+  display: none !important;
+}
+
+.goog-text-highlight {
+  background: none !important;
+  -webkit-box-shadow: none !important;
+  -moz-box-shadow: none !important;
+  box-shadow: none !important;
+  box-sizing: unset !important;
+  -webkit-box-sizing: unset !important;
+  -moz-box-sizing: unset !important;
+  position: relative !important;
+} 
+
 .goog-te-combo {
   width: 35px;
   opacity: 0;

--- a/app/assets/stylesheets/components/_index.scss
+++ b/app/assets/stylesheets/components/_index.scss
@@ -10,3 +10,4 @@
 @import "comparison";
 @import "drawer_item";
 @import "read_more";
+@import "google_translate";

--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -26,8 +26,3 @@ li {
   background-color: #203d69;
 }
 
-#google_translate_element {
-  position: absolute;
-  right: 0;
-  margin: 2px 4px;
-}

--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -26,8 +26,8 @@ li {
   background-color: #203d69;
 }
 
-// #google_translate_element {
-//   position: absolute;
-//   right: 0;
-//   margin: 2px 4px;
-// }
+#google_translate_element {
+  position: absolute;
+  right: 0;
+  margin: 2px 4px;
+}

--- a/app/javascript/plugins/readmore.js
+++ b/app/javascript/plugins/readmore.js
@@ -1,13 +1,19 @@
 const readMore = () => {
-  let readMoreElement = document.querySelector(".read-more");
+  let readMoreElement = document.querySelector("#btn-read-more");
   if (readMoreElement != null) {
     readMoreElement.addEventListener("click", (event) => {
       document.querySelector(".more").classList.toggle("active");
       document.querySelector(".dots").classList.toggle("active");
-      if (document.querySelector(".read-more").innerHTML === 'Read more') {
-        document.querySelector(".read-more").innerHTML = "Read less";
+      console.log(readMoreElement.classList);
+      if (readMoreElement.classList.contains("toggle-read-more") == false) {
+        console.log('Read More');
+        readMoreElement.innerText = "Read more";
+        readMoreElement.classList.add('toggle-read-more')
       } else {
-        document.querySelector(".read-more").innerHTML = "Read more";
+        console.log('Read Less');
+        readMoreElement.innerText = "Read less";
+        readMoreElement.classList.remove('toggle-read-more')
+
       }
     });
   }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -33,5 +33,15 @@
     <%= yield %>
     <!-- Render sticky footer navbar -->
     <%= render 'shared/footer' %>
+    <script type="text/javascript" src="https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
+    <script type="text/javascript">
+      // const duplicate_google_translate_counter = 0; // this should stop Google adding button multiple times
+      // console.log("duplicate_google_translate_counter" + duplicate_google_translate_counter)
+      function googleTranslateElementInit() {
+        translate_element = document.querySelector('#google_translate_element');
+        while (translate_element.firstChild) { translate_element.removeChild(translate_element.firstChild); }
+        new google.translate.TranslateElement({pageLanguage: 'ja'}, 'google_translate_element');
+      }
+    </script>
   </body>
 </html>

--- a/app/views/shared/_home_banner.html.erb
+++ b/app/views/shared/_home_banner.html.erb
@@ -2,10 +2,13 @@
   <%# Calling and rendering the barcode scanner %>
   <div class="container">
     <h1 class="normal">Get information on Japanese products by scanning their barcodes!</h1>
-    <% body_content = render 'shared/barcode_scanner' %>
-    <%= render 'shared/modal', modal_id: 'camera', modal_title: 'Show me your barcode!',
+    <% create_home_modal = false %>
+    <% if create_home_modal %>
+      <% body_content = render 'shared/barcode_scanner' %>
+      <%= render 'shared/modal', modal_id: 'camera', modal_title: 'Show me your barcode!',
         text_header: '', text_body: '', body_content: body_content,
         redirect_path: root_path, btn_modal_confirm: 'Home'  %>
+    <% end %>
     <div class="position-relative">
       <div class="scanner-line w-100"></div>
       <div class="d-flex bd-highlight m-3">

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -4,6 +4,10 @@
   <% end %>
   <% avatar_path = (current_user && current_user.photo.attached?) ? cl_image_path(current_user.photo.key, width: 24, height: 24, crop: :fill) : image_path("default-avatar.png") %>
   <div class="d-flex">
+    <div class="d-flex align-items-center">
+      <i id="fa-translate-icon" class="fas fa-language"></i>
+      <div id="google_translate_element"></div>
+    </div>
     <%= image_tag(avatar_path, class: "rounded-circle my-auto", style: "width: 24px; height: 24px;") if current_user %>
     <li class="nav-item dropdown">
       <a class="nav-link pl-3 pr-1" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
@@ -12,11 +16,8 @@
       <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
         <% if user_signed_in? %>
           <% username = (current_user.display_name.blank? || current_user.display_name.nil?) ? current_user.email.split('@')[0] : current_user.display_name  %>
-          <p class="dropdown-item disabled">Welcome, <%= username %>!</p>
+          <p class="dropdown-item disabled mb-1">Welcome, <%= username %>!</p>
           <div class="dropdown-divider"></div>
-          <%= link_to '#' do %>
-            <p class="dropdown-item">My User Profile</p>
-          <% end %>
           <%= link_to edit_user_registration_path do %>
             <p class="dropdown-item">Update my profile</p>
           <% end %>
@@ -29,14 +30,3 @@
     </li>
   </div>
 </nav>
-<div id="google_translate_element"></div>
-<script type="text/javascript">
-  // const duplicate_google_translate_counter = 0; // this should stop Google adding button multiple times
-  // console.log("duplicate_google_translate_counter" + duplicate_google_translate_counter)
-  function googleTranslateElementInit() {
-    translate_element = document.querySelector('#google_translate_element');
-    while (translate_element.firstChild) { translate_element.removeChild(translate_element.firstChild); }
-    new google.translate.TranslateElement({pageLanguage: 'ja'}, 'google_translate_element');
-  }
-</script>
-<script type="text/javascript" src="https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -31,12 +31,12 @@
 </nav>
 <div id="google_translate_element"></div>
 <script type="text/javascript">
-  var duplicate_google_translate_counter = 0; // this should stop Google adding button multiple times
+  // const duplicate_google_translate_counter = 0; // this should stop Google adding button multiple times
+  // console.log("duplicate_google_translate_counter" + duplicate_google_translate_counter)
   function googleTranslateElementInit() {
-    if (duplicate_google_translate_counter == 0) {
-      new google.translate.TranslateElement({pageLanguage: 'ja'}, 'google_translate_element');
-    }
-    duplicate_google_translate_counter++;
+    translate_element = document.querySelector('#google_translate_element');
+    while (translate_element.firstChild) { translate_element.removeChild(translate_element.firstChild); }
+    new google.translate.TranslateElement({pageLanguage: 'ja'}, 'google_translate_element');
   }
 </script>
 <script type="text/javascript" src="https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -29,7 +29,7 @@
     </li>
   </div>
 </nav>
-<%# <div id="google_translate_element"></div>
+<div id="google_translate_element"></div>
 <script type="text/javascript">
   var duplicate_google_translate_counter = 0; // this should stop Google adding button multiple times
   function googleTranslateElementInit() {
@@ -39,4 +39,4 @@
     duplicate_google_translate_counter++;
   }
 </script>
-<script type="text/javascript" src="https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script> %>
+<script type="text/javascript" src="https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -2,21 +2,27 @@
   <%= link_to root_path do %>
     <span class="navbar-brand mb-0 h1"><i class="fas fa-paw"></i> BarcSnap!</span>
   <% end %>
-  <% avatar_path = (current_user && current_user.photo.attached?) ? cl_image_path(current_user.photo.key, width: 24, height: 24, crop: :fill) : image_path("default-avatar.png") %>
-  <div class="d-flex">
-    <div class="d-flex align-items-center">
-      <i id="fa-translate-icon" class="fas fa-language"></i>
-      <div id="google_translate_element"></div>
+  <div class="d-flex"">
+    <div id="google-translate-container" class="d-flex align-items-center position-relative mr-2">
+      <div id="google_translate_element">
+      </div>
+      <div class="position-absolute d-flex align-items-center" style="z-index: -1;">
+        <i id="fa-translate-icon" class="fas fa-language"></i>
+        <!-- <i id="fa-translate-chevron" class="fas fa-chevron-down"></i> -->
+      </div>
     </div>
-    <%= image_tag(avatar_path, class: "rounded-circle my-auto", style: "width: 24px; height: 24px;") if current_user %>
     <li class="nav-item dropdown">
-      <a class="nav-link pl-3 pr-1" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+      <a class="nav-link pl-1 pr-1" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         <i class="fas fa-bars"></i>
       </a>
       <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
         <% if user_signed_in? %>
           <% username = (current_user.display_name.blank? || current_user.display_name.nil?) ? current_user.email.split('@')[0] : current_user.display_name  %>
-          <p class="dropdown-item disabled mb-1">Welcome, <%= username %>!</p>
+          <% avatar_path = (current_user && current_user.photo.attached?) ? cl_image_path(current_user.photo.key, width: 24, height: 24, crop: :fill) : image_path("default-avatar.png") %>
+          <div class="d-flex dropdown-item disabled mb-1 align-items-center align-content-center text-center">
+            <%= image_tag(avatar_path, class: "rounded-circle my-auto", style: "width: 24px; height: 24px;") if current_user %>
+            <p class="mb-0 ml-2">Welcome, <%= username %>!</p>
+          </div>
           <div class="dropdown-divider"></div>
           <%= link_to edit_user_registration_path do %>
             <p class="dropdown-item">Update my profile</p>

--- a/app/views/shared/_product_info.html.erb
+++ b/app/views/shared/_product_info.html.erb
@@ -37,7 +37,7 @@
               <span class="more">
                 <%= second_string = ingredients.slice(30,ingredients.length-30) %>
               </span>
-              <em><span class="read-more">Read more</span></em>
+              <button id="btn-read-more" class="btn btn-link p-0 toggle-read-more">Read more</button>
             <% else %>
               <%= ingredients %>
             <% end %>


### PR DESCRIPTION
Add the google translate button to the navbar (the dropdown looks better in desktop layout or on the phone).
![image](https://user-images.githubusercontent.com/78134040/131621912-44f72d91-b82f-4ee7-b49c-de74d3ea93f6.png)

Move user avatar to navbar menu instead. Remove "My User Profile" from the menu (because we don't have it).
![image](https://user-images.githubusercontent.com/78134040/131621950-ef1c29a1-12c8-47af-a4b8-d4984e259b67.png)

Automaticly translate content every page (only need to select once).
![image](https://user-images.githubusercontent.com/78134040/131621989-3a94f3fc-8b78-4588-b703-a50c32067733.png)
![image](https://user-images.githubusercontent.com/78134040/131622127-29832f28-6f27-4464-a047-8e443a49769c.png)

Change 'Read More' / 'Read Less' from text to button tag instead to prevent a problem where google translate modify page contents and cause event listener to stop working.
![image](https://user-images.githubusercontent.com/78134040/131623521-bb68f99c-4e9a-4e5f-a47f-ee016b32cf42.png)

So far every button works and can bring you to different pages. Also works with non-English languages as well.
![image](https://user-images.githubusercontent.com/78134040/131622306-9548629c-9c9e-4599-8564-779164e3f79d.png)
