### PR TITLE
Remove scanbar from user pages

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,6 +31,5 @@
     <%= render 'shared/navbar' %>
     <%= render 'shared/flashes' %>
     <%= yield %>
-    <!-- Render sticky footer navbar -->
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,6 +32,5 @@
     <%= render 'shared/flashes' %>
     <%= yield %>
     <!-- Render sticky footer navbar -->
-    <%= render 'shared/footer' %>
   </body>
 </html>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -51,3 +51,4 @@
 </div>
 <!-- Render footer -->
 <%= render 'shared/home_footer' %>
+<%= render 'shared/footer' %>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -51,4 +51,5 @@
 </div>
 <!-- Render footer -->
 <%= render 'shared/home_footer' %>
+<!-- Render sticky footer navbar -->
 <%= render 'shared/footer' %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -10,4 +10,5 @@
     <%= render 'shared/product_info_page' %>
   <% end %>
 </div>
+<!-- Render sticky footer navbar -->
 <%= render 'shared/footer' %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -10,3 +10,4 @@
     <%= render 'shared/product_info_page' %>
   <% end %>
 </div>
+<%= render 'shared/footer' %>


### PR DESCRIPTION
Scanbar (the footer navbar) no longer appears on devise (i.e. user) pages.
<img width="416" alt="Screen Shot 2021-09-01 at 15 47 45" src="https://user-images.githubusercontent.com/31387233/131625160-80faedab-ee16-4575-baab-daca956d4884.png">
<img width="416" alt="Screen Shot 2021-09-01 at 15 47 59" src="https://user-images.githubusercontent.com/31387233/131625179-f73bbf49-9684-4dfc-afed-5a11954efdd1.png">
<img width="416" alt="Screen Shot 2021-09-01 at 15 48 09" src="https://user-images.githubusercontent.com/31387233/131625182-b197f798-8c62-4551-99de-6cc813807e40.png">
<img width="416" alt="Screen Shot 2021-09-01 at 15 48 23" src="https://user-images.githubusercontent.com/31387233/131625185-720e7c60-3dcf-47a1-957e-087f76967b95.png">
<img width="416" alt="Screen Shot 2021-09-01 at 15 48 29" src="https://user-images.githubusercontent.com/31387233/131625188-ea58b61e-a359-4dad-b479-1237fa984c53.png">
<img width="416" alt="Screen Shot 2021-09-01 at 15 48 44" src="https://user-images.githubusercontent.com/31387233/131625191-2a3a2c5b-4afa-4da9-a5cb-22e9636f2578.png">
