### PR TITLE
adjust alert placement to not block scanbar

### DIFF
--- a/app/assets/stylesheets/components/_alert.scss
+++ b/app/assets/stylesheets/components/_alert.scss
@@ -1,6 +1,6 @@
 .alert {
   position: fixed;
-  bottom: 16px;
-  right: 16px;
+  bottom: 70px;
+  right: 4px;
   z-index: 1000;
 }


### PR DESCRIPTION
Alerts from signup, signin, profile update, barcode failure, etc. no longer block the scanbar.
<img width="306" alt="Screen Shot 2021-09-01 at 16 15 48" src="https://user-images.githubusercontent.com/31387233/131629129-9edbc341-acec-440c-8c81-c1273789b97d.png">
<img width="306" alt="Screen Shot 2021-09-01 at 16 14 54" src="https://user-images.githubusercontent.com/31387233/131629142-8e20eb34-e514-4bd1-bfe1-fa1e6774b23b.png">
<img width="832" alt="Screen Shot 2021-09-01 at 16 14 21" src="https://user-images.githubusercontent.com/31387233/131629147-06c21965-4c83-4f13-9360-b723cd8ad16c.png">
<img width="651" alt="Screen Shot 2021-09-01 at 16 11 53" src="https://user-images.githubusercontent.com/31387233/131629152-1aa3d78c-d2b4-4c60-bc59-020fe9fdbdec.png">
<img width="284" alt="Screen Shot 2021-09-01 at 16 11 51" src="https://user-images.githubusercontent.com/31387233/131629153-5d704b5d-3f1c-475a-b931-8ac87f403f80.png">
