### PR TITLE
Move scanbar button

### DIFF
--- a/app/javascript/plugins/scanditsdk.js
+++ b/app/javascript/plugins/scanditsdk.js
@@ -46,15 +46,17 @@ const initScanditSDK = () => {
           document.getElementById("multiple-field").setAttribute('value', false);
         });
       };
-      // Set "compare" value to "true" (unless on the homepage) when clicking "scan & compare" button (and "multiple" to "false")
-      barcodeCompareButton.addEventListener("click", () => {
-        if (scannerHomeButton) {
-          document.getElementById("compare-field").setAttribute('value', false);
-        } else {
-        document.getElementById("compare-field").setAttribute('value', true);
-        };
-        document.getElementById("multiple-field").setAttribute('value', false);
-      });
+      if (barcodeCompareButton) {
+        // Set "compare" value to "true" (unless on the homepage) when clicking "scan & compare" button (and "multiple" to "false")
+        barcodeCompareButton.addEventListener("click", () => {
+          if (scannerHomeButton) {
+            document.getElementById("compare-field").setAttribute('value', false);
+          } else {
+          document.getElementById("compare-field").setAttribute('value', true);
+          };
+          document.getElementById("multiple-field").setAttribute('value', false);
+        });
+      };
       // Set "multiple" value to "true" when clicking "multiple" button (and "compare" to "false")
       barcodeMultipleButton.addEventListener("click", () => {
         document.getElementById("multiple-field").setAttribute('value', true);

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,11 +1,11 @@
 <footer id="footer-barc">
   <div class="d-flex justify-content-center bg-light">
-    <div class="d-flex flex-grow-1 overflow-hidden m-0 p-0" style="max-width: 160px;">
+    <%# <div class="d-flex flex-grow-1 overflow-hidden m-0 p-0" style="max-width: 160px;">
       <a id="btn-scn-compare" class="d-flex mx-0 mb-0 px-3 pt-2 flex-column justify-content-around flex-grow-1 scanner-start
       barcode-compare btn bg-light hidding1" data-toggle="modal" data-target="#camera">
         <i class="fas fa-barcode mb-1"></i><span class="footer-text text-center">Scan & Compare</span>
       </a>
-    </div>
+    </div> %>
     <div class="d-flex flex-grow-1 overflow-hidden m-0 p-0" style="max-width: 160px;">
       <a id="btn-scn-single" class="d-flex mx-0 mb-0 px-3 pt-2 flex-column justify-content-around flex-grow-1 scanner-start
       scanner-new btn bg-light hidding2" data-toggle="modal" data-target="#camera">
@@ -15,7 +15,7 @@
     <div class="d-flex flex-grow-1 overflow-hidden m-0 p-0" style="max-width: 160px;">
       <a id="btn-scn-multiple" class="d-flex mx-0 mb-0 px-3 pt-2 flex-column justify-content-around flex-grow-1 scanner-start
       barcode-multiple btn bg-light hidding3" data-toggle="modal" data-target="#camera">
-        <i class="fas fa-tags mb-1"></i><span class="footer-text text-center">Scan Multiple</span>
+        <i class="fas fa-tags mb-1"></i><span class="footer-text text-center">Scan & Compare</span>
       </a>
     </div>
   </div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,11 +1,5 @@
 <footer id="footer-barc">
   <div class="d-flex justify-content-center bg-light">
-    <%# <div class="d-flex flex-grow-1 overflow-hidden m-0 p-0" style="max-width: 160px;">
-      <a id="btn-scn-compare" class="d-flex mx-0 mb-0 px-3 pt-2 flex-column justify-content-around flex-grow-1 scanner-start
-      barcode-compare btn bg-light hidding1" data-toggle="modal" data-target="#camera">
-        <i class="fas fa-barcode mb-1"></i><span class="footer-text text-center">Scan & Compare</span>
-      </a>
-    </div> %>
     <div class="d-flex flex-grow-1 overflow-hidden m-0 p-0" style="max-width: 160px;">
       <a id="btn-scn-single" class="d-flex mx-0 mb-0 px-3 pt-2 flex-column justify-content-around flex-grow-1 scanner-start
       scanner-new btn bg-light hidding2" data-toggle="modal" data-target="#camera">

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -15,7 +15,7 @@
     <div class="d-flex flex-grow-1 overflow-hidden m-0 p-0" style="max-width: 160px;">
       <a id="btn-scn-multiple" class="d-flex mx-0 mb-0 px-3 pt-2 flex-column justify-content-around flex-grow-1 scanner-start
       barcode-multiple btn bg-light hidding3" data-toggle="modal" data-target="#camera">
-        <i class="fas fa-tags mb-1"></i><span class="footer-text text-center">Scan & Compare</span>
+        <i class="fas fa-barcode mb-1"></i><span class="footer-text text-center">Scan & Compare</span>
       </a>
     </div>
   </div>

--- a/app/views/shared/_product_info.html.erb
+++ b/app/views/shared/_product_info.html.erb
@@ -10,7 +10,7 @@
       <div class="info-style border-bottom-0">
         <button id="btn-scn-compare" class="btn btn-light btn-sm position-absolute mx-1 my-1 scanner-start barcode-compare hidding1"
          data-toggle="modal" data-target="#camera" style="bottom: 0px; right: 0px;">
-          <p class="mb-0" style="width: 100%; font-size: .8rem;" style="top: 0px; right: 0px;"><i class="fas fa-camera" style="font-size: .8rem;"></i> Compare</p>
+          <p class="mb-0" style="width: 100%; font-size: .8rem;"><i class="fas fa-camera" style="font-size: .8rem;"></i> Compare</p>
         </button>
       </div>
     </div>

--- a/app/views/shared/_product_info.html.erb
+++ b/app/views/shared/_product_info.html.erb
@@ -18,11 +18,11 @@
         <p class="mb-1"><strong>Category</strong></p>
       </div>
       <div class="row info-style p-0 d-flex justify-content-center">
-      <% @product.tag_list.each do |tag| %>
-        <%= link_to (product_path(0) + "?sort_by=tag&tag_name=#{tag}") do %>
-          <p class="badge badge-pill badge-dark mx-1"><%= "#{tag}" %></p>
+        <% @product.tag_list.each do |tag| %>
+          <%= link_to (product_path(0) + "?sort_by=tag&tag_name=#{tag}") do %>
+            <p class="badge badge-pill badge-dark mx-1"><%= "#{tag}" %></p>
+          <% end %>
         <% end %>
-      <% end %>
       </div>
       <% if defined?(ingredients) && ingredients && ingredients.length.positive? %>
         <% unless allergens == "No allergens found." %>
@@ -40,18 +40,18 @@
             <i class="fas fa-apple-alt text-success"></i>
             <strong> Ingredients</strong>
             <% if @allergies_matched_count > 0 %>
-            <p class="mx-0 my-0 badge">
-            </p>
-            <p class="mx-0 my-1 badge badge-pill badge-danger">
-              <strong> <%= @allergies_matched_count %> </strong>
-            </p>
+              <p class="mx-0 my-0 badge">
+              </p>
+              <p class="mx-0 my-1 badge badge-pill badge-danger">
+                <strong> <%= @allergies_matched_count %> </strong>
+              </p>
             <% end %>
             <% if @dislikes_matched_count > 0 %>
-            <p class="mx-0 my-1 badge">
-            </p>
-            <p class="mx-0 my-1 badge badge-pill badge-warning">
-              <strong> <%= @dislikes_matched_count %> </strong>
-            </p>
+              <p class="mx-0 my-1 badge">
+              </p>
+              <p class="mx-0 my-1 badge badge-pill badge-warning">
+                <strong> <%= @dislikes_matched_count %> </strong>
+              </p>
             <% end %>
           </p>
         </div>
@@ -77,8 +77,14 @@
       <div class="row p-0 d-flex justify-content-center">
         <p class="mb-1"><strong>Company</strong></p>
       </div>
-      <div class="row info-style p-0 d-flex justify-content-center border-bottom-0">
+      <div class="row info-style p-0 d-flex justify-content-center">
         <p class="mb-1"><%= company_name %></p>
+      </div>
+      <div class="row d-grid gap-2 info-style p-0 d-flex justify-content-center border-bottom-0">
+        <button id="btn-scn-compare" class="mt-auto align-self-center mx-0 mb-1 scanner-start barcode-compare btn hidding1"
+        style="width: 100%;" data-toggle="modal" data-target="#camera">
+          <span class="footer-text text-center">Compare to this product.</span>
+        </button>
       </div>
     </div>
   </div>
@@ -93,16 +99,16 @@
     inputText.innerHTML = innerHTML;
     }
   }
-
+  
   function parsing(rubyarray) {
     var current = rubyarray;
     answer = current.replace(/[&quot;]+/g, '"');
     var array = JSON.parse(answer);
     return array
   }
-
+  
   array_allergies = parsing("<%= @array_allergies %>");
-
+  
   array_allergies.forEach(function (item) {
     if (!(document.getElementById("inputText")==null)) {
       highlight2(item, "inputText", "highlight");
@@ -111,7 +117,7 @@
       highlight2(item, "inputText2", "highlight");
     }
   });
-
+  
   array_dislikes = parsing("<%= @array_dislikes %>")
   array_dislikes.forEach(function (item) {
     if (!(document.getElementById("inputText")==null)) {

--- a/app/views/shared/_product_info.html.erb
+++ b/app/views/shared/_product_info.html.erb
@@ -1,12 +1,18 @@
 <div class="close-modal">
   <div id="product-background-box" class="mx-0 my-1 p-3 position-relative border-bottom bg-white">
     <div class="card-category-product product-background p-0" style="background-color: white; background-image: url(<%= bg_img_url %>); background-size: contain;">
-      <p id="badge-rating" class="mx-1 my-1 position-absolute badge badge-pill badge-secondary" style="bottom: 0px; right: 0px;"><strong> ⭐ <%= rating %></strong> (<%= review_count  %>)</p>
+      <p id="badge-rating" class="mx-1 my-1 position-absolute badge badge-pill badge-secondary" style="top: 0px; right: 0px;"><strong> ⭐ <%= rating %></strong> (<%= review_count  %>)</p>
       <%= link_to product_favorites_path(@product), method: :post, remote: true do %>
         <div id="btn-favorite-<%= @product.id %>" style="position:absolute; left: 0; top: 0; font-size:1rem;">
           <%= render 'products/favorite_button', product_favorited: @product_favorited %>
         </div>
       <% end %>
+      <div class="info-style border-bottom-0">
+        <button id="btn-scn-compare" class="btn btn-light btn-sm position-absolute mx-1 my-1 scanner-start barcode-compare hidding1"
+         data-toggle="modal" data-target="#camera" style="bottom: 0px; right: 0px;">
+          <p class="mb-0" style="width: 100%; font-size: .8rem;" style="top: 0px; right: 0px;"><i class="fas fa-camera" style="font-size: .8rem;"></i> Compare</p>
+        </button>
+      </div>
     </div>
   </div>
   <div class="card-category bg-white w-100 text-justify-content-around">
@@ -79,12 +85,6 @@
       </div>
       <div class="row info-style p-0 d-flex justify-content-center">
         <p class="mb-1"><%= company_name %></p>
-      </div>
-      <div class="row d-grid gap-2 info-style p-0 d-flex justify-content-center border-bottom-0">
-        <button id="btn-scn-compare" class="mt-auto align-self-center mx-0 mb-1 scanner-start barcode-compare btn hidding1"
-        style="width: 100%;" data-toggle="modal" data-target="#camera">
-          <span class="footer-text text-center">Compare to this product.</span>
-        </button>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Remove "compare" button from the scanbar and put it on the product show page. "Scan multiple" is now "Scan & Compare" and uses the barcode icon.
![Screen Shot 2021-09-03 at 01 25 55](https://user-images.githubusercontent.com/31387233/131881496-11236e9c-1f55-47d0-bcb0-63b278643aea.png)
![Screen Shot 2021-09-03 at 01 25 39](https://user-images.githubusercontent.com/31387233/131881506-fcb2399a-c8a8-46f7-9e28-b32baa03b685.png)
